### PR TITLE
Fixed two issues related to directory navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ saydos.exe "Dump" "%InputDiskImageFilePath%" "%OutputSectorAndFileFolderPath%"
 ```
 
 * `InputDiskImageFilePath`: The disk image you want to extract sectors and files from
-* `OuputSectorAndFileFolderPath`: The directory you want to output the data to. The folder will need to be created for the program to run.
+* `OutputSectorAndFileFolderPath`: The directory you want to output the data to. The folder will need to be created for the program to run.
 
 ### Writing
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See below for terminal usage information.
 
 ### Dumping
 ```bash
-saydos.exe "Dump" "%InputDiskImageFilePath%" "%OuputSectorAndFileFolderPath%"
+saydos.exe "Dump" "%InputDiskImageFilePath%" "%OutputSectorAndFileFolderPath%"
 ```
 
 * `InputDiskImageFilePath`: The disk image you want to extract sectors and files from

--- a/SayDos/Program.cs
+++ b/SayDos/Program.cs
@@ -148,11 +148,13 @@ namespace SayDos
                             throw new Exception($"File doesn't exist: {Path.Combine(folder, ROOT_DIRECTORY_FILE)}");
                         }
 
-                        Directory.SetCurrentDirectory(folder);
-                        Directory.SetCurrentDirectory(FOLDER_SECTOR);
+                        var currentDirectory = Directory.GetCurrentDirectory();
 
                         // Read dumped root directory info
                         var rdTable = JsonConvert.DeserializeObject<List<SayDosRootDirectory>>(new StreamReader(Path.Combine(folder, ROOT_DIRECTORY_FILE)).ReadToEnd());
+
+                        Directory.SetCurrentDirectory(folder);
+                        Directory.SetCurrentDirectory(FOLDER_SECTOR);
 
                         // Read dumped MBR header and other system data (e.g. stuff that aren't files)
                         List<byte[]> systemSectors = new();
@@ -226,6 +228,8 @@ namespace SayDos
                         byte[] final = Enumerable.Repeat((byte)0xFF, 0xB4000).ToArray();
 
                         Array.Copy(merged, 0, final, 0, merged.Length);
+
+                        Directory.SetCurrentDirectory(currentDirectory);
 
                         File.WriteAllBytes(romPath, final);
 


### PR DESCRIPTION
When running the `Write` mode, the program tries to read the `ROOT_DIRECTORY_FILE` from the `FOLDER_SECTOR` directory, instead of the provided `InputSectorAndFileFolderPath`. This has been fixed.

When running the `Write` mode, the program outputs the new diskimage to `OutputDiskImageFilePath` in the `FOLDER_SECTOR` directory, instead of the current working directory. This has also been fixed.